### PR TITLE
bump new version: v0.2.2

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -3,7 +3,7 @@ package version
 const (
 	// TMVersionDefault is the used as the fallback version of PellDVS
 	// when not using git describe. It is formatted with semantic versioning.
-	TMCoreSemVer = "0.2.1"
+	TMCoreSemVer = "0.2.2"
 	// ABCISemVer is the semantic version of the ABCI protocol
 	ABCISemVer  = "2.0.0"
 	ABCIVersion = ABCISemVer


### PR DESCRIPTION
- bump new version `0.2.2` 

