### PR TITLE
upgrade pelldvs interactor to v0.0.15

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,6 +41,15 @@ jobs:
         run: make docker-test-pelle2e
         env:
           TIMEOUT_FOR_TASK_PROCESS: 60
+      - name: Print logs - emulator
+        run: make docker-emulator-logs-no-follow
+        if: always()
+      - name: Print logs - aggregator
+        run: make docker-aggregator-logs-no-follow
+        if: always()
+      - name: Print logs - operator
+        run: make docker-operator-logs-no-follow
+        if: always()
       - name: Stop services for cleanup
         working-directory: test/e2e
         run: make docker-down

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,12 +43,15 @@ jobs:
           TIMEOUT_FOR_TASK_PROCESS: 60
       - name: Print logs - emulator
         run: make docker-emulator-logs-no-follow
+        working-directory: test/e2e
         if: always()
       - name: Print logs - aggregator
         run: make docker-aggregator-logs-no-follow
+        working-directory: test/e2e
         if: always()
       - name: Print logs - operator
         run: make docker-operator-logs-no-follow
+        working-directory: test/e2e
         if: always()
       - name: Stop services for cleanup
         working-directory: test/e2e

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,9 +29,6 @@ jobs:
           cache: false
       - name: private
         run: git config --global url."https://${GITHUB_TOKEN}:x-oauth-basic@github.com/0xPellNetwork".insteadOf "https://github.com/0xPellNetwork"
-      - uses: golangci/golangci-lint-action@v8
-        with:
-          version: latest
-          args: --timeout 10m
-          github-token: ${{ secrets.GH_TOKEN }}
-        # if: "env.GIT_DIFF != ''"
+      - name: Run linter via Makefile
+        run: make lint
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,4 +31,3 @@ jobs:
         run: git config --global url."https://${GITHUB_TOKEN}:x-oauth-basic@github.com/0xPellNetwork".insteadOf "https://github.com/0xPellNetwork"
       - name: Run linter via Makefile
         run: make lint
-

--- a/.github/workflows/markdown-linter.yml
+++ b/.github/workflows/markdown-linter.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   build:
     name: Super linter
-    runs-on: [ "Linux", "X64", "ci"]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout Code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v0.4.0
+
+### Bug Fixes
+
+- (indexer) [#28](https://github.com/0xPellNetwork/pelldvs/pull/28) bugfix: do not return error while can't get operator from store in the in the loop in OperatorInfoProvider.GetOperatorsDVSStateAtBlock and GetOperatorsStateAtBlock
+
 ## v0.3.0
 
 ### Features
@@ -11,9 +17,9 @@
 
 ### Improvements
 
-- (CI) [#7](https://github.com/0xPellNetwork/pelldvs/pull/7) ci: add changelog check in CI  
-- (CI) [#11](https://github.com/0xPellNetwork/pelldvs/pull/11) ci: retrieve E2E port config from GitHub variables  
-- (refactor) [#9](https://github.com/0xPellNetwork/pelldvs/pull/9) refactor: rename abci to avsi  
+- (CI) [#7](https://github.com/0xPellNetwork/pelldvs/pull/7) ci: add changelog check in CI
+- (CI) [#11](https://github.com/0xPellNetwork/pelldvs/pull/11) ci: retrieve E2E port config from GitHub variables
+- (refactor) [#9](https://github.com/0xPellNetwork/pelldvs/pull/9) refactor: rename abci to avsi
 - (refactor) [#8](https://github.com/0xPellNetwork/pelldvs/pull/8) refactor: update private validator interface
 - (fix) [#12](https://github.com/0xPellNetwork/pelldvs/pull/12) fix: task failure when aggregator result does not meet threshold
 - (refactor) [#15](https://github.com/0xPellNetwork/pelldvs/pull/15) refactor: make aggregator reactor asynchronously handle requests
@@ -27,7 +33,7 @@
 
 ## v0.2.2
 
-v0.2.2 includes a version release CI script fix.  
+v0.2.2 includes a version release CI script fix.
 
 ## v0.2.0
 

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indi
 
 require (
 	github.com/0xPellNetwork/pell-middleware-contracts v0.2.32
-	github.com/0xPellNetwork/pelldvs-interactor v0.0.14
+	github.com/0xPellNetwork/pelldvs-interactor v0.0.15
 	github.com/0xPellNetwork/pelldvs-libs v0.2.0
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/cometbft/cometbft-db v0.14.1

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/0xPellNetwork/pelldvs-interactor v0.0.12 h1:QwGFx4EG/5qE1CEd8gljvOjD3
 github.com/0xPellNetwork/pelldvs-interactor v0.0.12/go.mod h1:kHbDu0iVhdwF38ZVDB2Fnsg87+gj74wAnaKz+wPwb/w=
 github.com/0xPellNetwork/pelldvs-interactor v0.0.14 h1:vcC0DzK9JNz6x/r8SA+fAcQiata/K/PdQhfIe88JyFQ=
 github.com/0xPellNetwork/pelldvs-interactor v0.0.14/go.mod h1:kHbDu0iVhdwF38ZVDB2Fnsg87+gj74wAnaKz+wPwb/w=
+github.com/0xPellNetwork/pelldvs-interactor v0.0.15 h1:1/+jM0JiJJa/h6UcoxJjb77BgyFLbEPKzHe1X4Exy9s=
+github.com/0xPellNetwork/pelldvs-interactor v0.0.15/go.mod h1:kHbDu0iVhdwF38ZVDB2Fnsg87+gj74wAnaKz+wPwb/w=
 github.com/0xPellNetwork/pelldvs-libs v0.2.0 h1:fNyzJKhH5Iux1YVPddLVwR/txPkbkRvE5+VunS7tFeg=
 github.com/0xPellNetwork/pelldvs-libs v0.2.0/go.mod h1:mU9ltThnyjDpKZHnOuJvMqbQU1O99P4cOAecTUKDAIY=
 github.com/AlecAivazis/survey/v2 v2.3.7 h1:6I/u8FvytdGsgonrYsVn2t8t4QiRnh6QSTqkkhIiSjQ=

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -33,6 +33,9 @@ docker-emulator-down:
 docker-emulator-logs:
 	@docker compose logs -f emulator
 
+docker-emulator-logs-no-follow:
+	@docker compose logs emulator
+
 docker-emulator-bash:
 	@docker compose exec -it emulator bash
 
@@ -50,6 +53,9 @@ docker-aggregator-down:
 docker-aggregator-logs:
 	@docker compose logs -f aggregator
 
+docker-aggregator-logs-no-follow:
+	@docker compose logs aggregator
+
 docker-aggregator-bash:
 	@docker compose exec -it aggregator bash
 
@@ -66,6 +72,9 @@ docker-operator-down:
 
 docker-operator-logs:
 	@docker compose logs -f operator
+
+docker-operator-logs-no-follow:
+	@docker compose logs operator
 
 docker-operator-bash:
 	@docker compose exec -it operator bash

--- a/test/e2e/docker/operator/Dockerfile
+++ b/test/e2e/docker/operator/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -L https://foundry.paradigm.xyz | bash
 ENV PATH="$PATH:/root/.foundry/bin"
 RUN foundryup
 
-RUN go install github.com/mikefarah/yq/v4@latest
+RUN go install github.com/mikefarah/yq/v4@v4.45.2
 COPY --from=build /app/pelldvs/build/pelldvs /usr/bin/pelldvs
 COPY ./docker/operator/scripts /root/scripts
 COPY ./docker/ssh /root/.ssh

--- a/test/e2e/docker/operator/Dockerfile
+++ b/test/e2e/docker/operator/Dockerfile
@@ -1,7 +1,7 @@
 FROM pelldvs/e2e-pelldvs:latest AS build
 
 ########## Setup runtime env ##########
-FROM golang:1.23-bullseye AS runtime
+FROM golang:1.23-bookworm AS runtime
 RUN apt-get update -yqq && apt-get install -yqq openssh-server curl jq less
 RUN mkdir -p /run/sshd && chmod 0755 /run/sshd
 

--- a/test/e2e/docker/pelldvs/Dockerfile
+++ b/test/e2e/docker/pelldvs/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-bullseye AS build
+FROM golang:1.23-bookworm AS build
 
 RUN --mount=type=secret,id=github_token \
     if [ ! -s /run/secrets/github_token ]; then echo "github token is not set via secrets" >&2; exit 1; fi; \
@@ -36,7 +36,7 @@ RUN --mount=type=cache,target="/go/pkg/mod" \
     make build
 
 ########## Setup runtime env ##########
-FROM golang:1.23-bullseye AS runtime
+FROM golang:1.23-bookworm AS runtime
 RUN apt-get update -yqq && apt-get install -yqq openssh-server curl jq less
 RUN mkdir -p /run/sshd && chmod 0755 /run/sshd
 

--- a/test/e2e/docker/pelldvs/Dockerfile
+++ b/test/e2e/docker/pelldvs/Dockerfile
@@ -44,7 +44,7 @@ RUN curl -L https://foundry.paradigm.xyz | bash
 ENV PATH="$PATH:/root/.foundry/bin"
 RUN foundryup
 
-RUN go install github.com/mikefarah/yq/v4@latest
+RUN go install github.com/mikefarah/yq/v4@v4.45.2
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 COPY --from=build /app/pelldvs/build/pelldvs /usr/bin/pelldvs
 COPY --from=build /app/pell-emulator/build/pell-emulator /usr/bin/pell-emulator

--- a/test/e2e/docker/pelle2e/Dockerfile
+++ b/test/e2e/docker/pelle2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-bullseye AS build
+FROM golang:1.23-bookworm AS build
 
 RUN --mount=type=secret,id=github_token \
     if [ ! -s /run/secrets/github_token ]; then echo "github token is not set via secrets" >&2; exit 1; fi; \
@@ -24,7 +24,7 @@ RUN --mount=type=cache,target="/go/pkg/mod" \
     go build -o build/pelle2e test/e2e/pelle2e/cmd/pelle2e/main.go
 
 ########## Setup runtime env ##########
-FROM golang:1.23-bullseye AS runtime
+FROM golang:1.23-bookworm AS runtime
 RUN apt-get update -yqq && apt-get install -yqq openssh-server curl jq less
 RUN mkdir -p /run/sshd && chmod 0755 /run/sshd
 

--- a/test/e2e/docker/pelle2e/Dockerfile
+++ b/test/e2e/docker/pelle2e/Dockerfile
@@ -32,7 +32,7 @@ RUN curl -L https://foundry.paradigm.xyz | bash
 ENV PATH="$PATH:/root/.foundry/bin"
 RUN foundryup
 
-RUN go install github.com/mikefarah/yq/v4@latest
+RUN go install github.com/mikefarah/yq/v4@v4.45.2
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 COPY --from=build /app/pelldvs/build/pelle2e /usr/bin/pelle2e
 COPY ./test/e2e/docker/pelldvs/scripts /root/scripts


### PR DESCRIPTION
- upgrade pelldvs interactor to v0.0.15
- e2e: fix e2e by upgrading golang base image, the latest version of `cast`don't works on golang/1.23-bullseye, change to bookworm.
- ci/e2e: always print logs for debug what happend in containers after the test job.